### PR TITLE
Reduce motion for low-end devices

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/components/motion-primitives/in-view.tsx
+++ b/src/components/motion-primitives/in-view.tsx
@@ -7,6 +7,7 @@ import {
   Transition,
   UseInViewOptions,
 } from 'motion/react';
+import useReducedMotion from '@/hooks/useReducedMotion';
 
 export type InViewProps = {
   children: ReactNode;
@@ -31,10 +32,15 @@ export function InView({
   viewOptions,
   as = 'div',
 }: InViewProps) {
+  const reduceMotion = useReducedMotion();
   const ref = useRef(null);
   const isInView = useInView(ref, viewOptions);
-
   const MotionComponent = motion[as as keyof typeof motion] as typeof as;
+
+  if (reduceMotion) {
+    const Component = as as React.ElementType;
+    return <Component>{children}</Component>;
+  }
 
   return (
     <MotionComponent

--- a/src/components/motion-primitives/infinite-slider.tsx
+++ b/src/components/motion-primitives/infinite-slider.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import { useMotionValue, animate, motion } from 'motion/react';
 import { useState, useEffect } from 'react';
 import useMeasure from 'react-use-measure';
+import useReducedMotion from '@/hooks/useReducedMotion';
 
 export type InfiniteSliderProps = {
   children: React.ReactNode;
@@ -28,8 +29,10 @@ export function InfiniteSlider({
   const translation = useMotionValue(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [key, setKey] = useState(0);
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
+    if (reduceMotion) return;
     let controls;
     const size = direction === 'horizontal' ? width : height;
     const contentSize = size + gap;
@@ -75,6 +78,7 @@ export function InfiniteSlider({
     isTransitioning,
     direction,
     reverse,
+    reduceMotion,
   ]);
 
   const hoverProps = speedOnHover
@@ -89,6 +93,10 @@ export function InfiniteSlider({
         },
       }
     : {};
+
+  if (reduceMotion) {
+    return <div className={cn('overflow-hidden', className)}>{children}</div>;
+  }
 
   return (
     <div className={cn('overflow-hidden', className)}>

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Detects when the user requests reduced motion or when the connection
+ * indicates data saving / low quality. Falls back to reduced motion when the
+ * browser signals either condition so animations can be skipped on low-end
+ * devices or slow networks.
+ */
+export function useReducedMotion() {
+  const [reduce, setReduce] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const connection = (navigator as any)?.connection;
+
+    const update = () => {
+      const saveData = connection?.saveData;
+      const slowConnection = connection?.effectiveType?.includes('2g');
+      setReduce(mediaQuery.matches || saveData || slowConnection);
+    };
+
+    update();
+    mediaQuery.addEventListener('change', update);
+    connection?.addEventListener?.('change', update);
+
+    return () => {
+      mediaQuery.removeEventListener('change', update);
+      connection?.removeEventListener?.('change', update);
+    };
+  }, []);
+
+  return reduce;
+}
+
+export default useReducedMotion;


### PR DESCRIPTION
## Summary
- add `useReducedMotion` hook to respect user motion preferences and slow network connections
- skip heavy animations in `InView` and `InfiniteSlider` when reduced motion is detected
- globally disable CSS animations for `prefers-reduced-motion`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b88700a6483229cfb013b86440d88