### PR TITLE
Fix DOM property warning and prioritize LCP image

### DIFF
--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -53,7 +53,7 @@ export default function ContentSection() {
             alt="team image"
             height="480"
             width="720"
-            loading="lazy"
+            priority
           />
         </ScrollView>
         <ScrollView>

--- a/src/components/sections/home/logo-cloud.tsx
+++ b/src/components/sections/home/logo-cloud.tsx
@@ -22,7 +22,7 @@ export default function LogoCloud() {
                     fill="currentColor"
                     fillRule="evenodd"
                     d="M5.243 8.375c-1.168 1.334-2.785 2.828-3.173 4.692c-.612 2.938 2.962 2.858 4.697 2.141c5.105-2.11 10.155-4.353 15.233-6.53c-4.937 1.315-9.857 2.699-14.812 3.945c-3.545.892-2.855-2.272-1.945-4.248"
-                    clip-rule="evenodd"
+                    clipRule="evenodd"
                   />
                 </svg>
               </div>


### PR DESCRIPTION
## Summary
- fix invalid `clip-rule` attribute in logo cloud SVG
- mark hero image as priority for faster LCP

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b909b29c48322a2a4c196976fdb67