### PR TITLE
Close mobile menu after navigation

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -75,6 +75,7 @@ export const HeroHeader = () => {
                       <Link
                         href={item.href}
                         className="text-muted-foreground hover:text-accent-foreground block duration-150"
+                        onClick={() => setMenuState(false)}
                       >
                         <span>{item.name}</span>
                       </Link>
@@ -98,7 +99,7 @@ export const HeroHeader = () => {
                   size="sm"
                   className={cn(isScrolled && "lg:hidden")}
                 >
-                  <Link href="/full-version">
+                  <Link href="/full-version" onClick={() => setMenuState(false)}>
                     <span>Full Version</span>
                   </Link>
                 </Button>
@@ -107,7 +108,7 @@ export const HeroHeader = () => {
                   size="sm"
                   className={cn(isScrolled ? "lg:inline-flex" : "hidden")}
                 >
-                  <Link href="/full-version">
+                  <Link href="/full-version" onClick={() => setMenuState(false)}>
                     <span>Join waitlist</span>
                   </Link>
                 </Button>


### PR DESCRIPTION
## Summary
- Close mobile navigation menu after selecting a section
- Close mobile menu when selecting "Full Version" or "Join waitlist" buttons

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b94d228f4832286d4a0889cb18450