### PR TITLE
Fix language switch tooltip persistence and position

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -103,18 +103,18 @@ export const HeroHeader = () => {
                     <span>Partner with us</span>
                   </Link>
                 </Button>
-                <div className="relative group">
-                  <Button
-                    asChild
-                    variant="outline"
-                    size="sm"
-                    className={cn(isScrolled && "lg:fixed lg:right-6 lg:top-4")}
-                  >
+                <div
+                  className={cn(
+                    "relative group pb-2",
+                    isScrolled && "lg:fixed lg:right-6 lg:top-4"
+                  )}
+                >
+                  <Button asChild variant="outline" size="sm">
                     <Link href="#" onClick={() => setMenuState(false)}>
                       <span>EN</span>
                     </Link>
                   </Button>
-                  <div className="bg-background absolute right-0 top-full z-10 mt-2 hidden w-32 rounded-2xl border p-3 shadow-2xl shadow-zinc-300/20 group-hover:block">
+                  <div className="bg-background absolute right-0 top-full z-10 hidden w-32 rounded-2xl border p-3 shadow-2xl shadow-zinc-300/20 group-hover:block">
                     <button className="block w-full rounded-md px-2 py-1 text-left text-sm hover:bg-accent hover:text-accent-foreground">
                       English
                     </button>


### PR DESCRIPTION
## Summary
- keep language selector tooltip visible when moving cursor away from button
- fix language tooltip position when header button becomes fixed on scroll

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689bbff0438483228baec5c20aa80135