### PR TITLE
Fix language switcher alignment in Safari and localize header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,10 +7,12 @@ import React from "react";
 import { cn } from "@/lib/utils";
 import { NAV_LINKS } from "@/content/nav";
 import { LanguageSwitcher } from "./language-switcher";
+import { useTranslation } from "react-i18next";
 
 export const HeroHeader = () => {
   const [menuState, setMenuState] = React.useState(false);
   const [isScrolled, setIsScrolled] = React.useState(false);
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     const handleScroll = () => {
@@ -58,13 +60,13 @@ export const HeroHeader = () => {
 
             <div className="absolute inset-0 m-auto hidden size-fit lg:block">
               <ul className="flex gap-8 text-sm">
-                {NAV_LINKS.map((item, index) => (
-                  <li key={index}>
+                {NAV_LINKS.map((item) => (
+                  <li key={item.key}>
                     <Link
                       href={item.href}
                       className=" hover:text-accent-foreground block duration-150"
                     >
-                      <span>{item.name}</span>
+                      <span>{t(`header.nav.${item.key}`)}</span>
                     </Link>
                   </li>
                 ))}
@@ -74,14 +76,14 @@ export const HeroHeader = () => {
             <div className="bg-background in-data-[state=active]:block lg:in-data-[state=active]:flex mb-6 hidden w-full flex-wrap items-center justify-end space-y-8 rounded-3xl border p-6 shadow-2xl shadow-zinc-300/20 md:flex-nowrap lg:m-0 lg:flex lg:w-fit lg:gap-6 lg:space-y-0 lg:border-transparent lg:bg-transparent lg:p-0 lg:shadow-none dark:shadow-none dark:lg:bg-transparent">
               <div className="lg:hidden">
                 <ul className="space-y-6 text-base">
-                  {NAV_LINKS.map((item, index) => (
-                    <li key={index}>
+                  {NAV_LINKS.map((item) => (
+                    <li key={item.key}>
                       <Link
                         href={item.href}
                         className="text-muted-foreground hover:text-accent-foreground block duration-150"
                         onClick={() => setMenuState(false)}
                       >
-                        <span>{item.name}</span>
+                        <span>{t(`header.nav.${item.key}`)}</span>
                       </Link>
                     </li>
                   ))}
@@ -104,13 +106,13 @@ export const HeroHeader = () => {
                   className={cn(isScrolled && "lg:hidden")}
                 >
                   <Link href="/full-version" onClick={() => setMenuState(false)}>
-                    <span>Partner with us</span>
+                    <span>{t("header.cta")}</span>
                   </Link>
                 </Button>
                 <LanguageSwitcher
                   className={cn(
                     "hidden lg:block",
-                    isScrolled && "lg:fixed lg:right-6 lg:top-4"
+                    isScrolled && "lg:absolute lg:right-6 lg:top-4"
                   )}
                 />
                 {/* <Button

--- a/src/content/nav.ts
+++ b/src/content/nav.ts
@@ -1,18 +1,18 @@
 export const NAV_LINKS = [
   {
-    name: "Home",
+    key: "home",
     href: "/#home",
   },
   {
-    name: "About",
+    key: "about",
     href: "/#about",
   },
   {
-    name: "Services",
+    key: "services",
     href: "/#services",
   },
   {
-    name: "Portfolio",
+    key: "portfolio",
     href: "/#portfolio",
   },
 ];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,6 +9,15 @@ const resources = {
         title: 'Design With Intent, Engineering With Precision.',
         subtitle: 'Custom websites and web apps on modern stacks-fast delivery, strong reliability, real ROI.',
       },
+      header: {
+        nav: {
+          home: 'Home',
+          about: 'About',
+          services: 'Services',
+          portfolio: 'Portfolio',
+        },
+        cta: 'Partner with us',
+      },
     },
   },
   ru: {
@@ -17,6 +26,15 @@ const resources = {
         title: 'Дизайн с намерением, инженерия с точностью.',
         subtitle: 'Пользовательские сайты и веб-приложения на современных стеках — быстрая доставка, высокая надёжность, реальная окупаемость.',
       },
+      header: {
+        nav: {
+          home: 'Главная',
+          about: 'О нас',
+          services: 'Услуги',
+          portfolio: 'Портфолио',
+        },
+        cta: 'Сотрудничать с нами',
+      },
     },
   },
   es: {
@@ -24,6 +42,15 @@ const resources = {
       hero: {
         title: 'Diseño con intención, ingeniería con precisión.',
         subtitle: 'Sitios web y aplicaciones web personalizados con pilas modernas: entrega rápida, gran fiabilidad y verdadero retorno de inversión.',
+      },
+      header: {
+        nav: {
+          home: 'Inicio',
+          about: 'Nosotros',
+          services: 'Servicios',
+          portfolio: 'Portafolio',
+        },
+        cta: 'Colabora con nosotros',
       },
     },
   },


### PR DESCRIPTION
## Summary
- fix language switcher positioning on scroll with absolute layout for cross-browser support
- localize header navigation and call-to-action button via i18next

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689bcca0605c8322a2794d1c7127db85