### PR TITLE
Fix language switcher spacing for symmetry

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -112,7 +112,7 @@ export const HeroHeader = () => {
                 <LanguageSwitcher
                   className={cn(
                     "hidden lg:block",
-                    isScrolled && "lg:absolute lg:right-6 lg:top-4"
+                    isScrolled && "lg:absolute lg:right-5 lg:top-4"
                   )}
                 />
                 {/* <Button


### PR DESCRIPTION
## Summary
- adjust LanguageSwitcher positioning so right margin matches logo's left margin when header is scrolled

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689bd050ed008322acb3f93e96665d1e