### PR TITLE
Add translations for hero CTAs and About section

### DIFF
--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -1,56 +1,32 @@
-import { Circle, Cpu, Lock, Sparkles, Zap } from "lucide-react";
+import { Circle } from "lucide-react";
 import { ScrollView } from "./scroll-view";
 import Image from "next/image";
-
-const ourPrinciples = [
-  {
-    title: "Design × Engineering",
-    description:
-      "Clean design and robust code working together to deliver outcomes.",
-  },
-  {
-    title: "Custom Web Experiences",
-    description:
-      "From animated marketing pages to complex product UIs.",
-  },
-
-  {
-    title: "Measurable Impact",
-    description:
-      "Faster load times, higher conversion, and reliable performance.",
-  },
-  {
-    title: "Distributed & Bilingual",
-    description:
-      "Fully remote team, RU/EN, operating worldwide.",
-  },
-];
+import { useTranslation } from "react-i18next";
 
 export default function ContentSection() {
+  const { t } = useTranslation();
+  const ourPrinciples = t("about.principles", {
+    returnObjects: true,
+  }) as { title: string; description: string }[];
+
   return (
     <section className="py-16 md:py-32" id="about">
       <div className="mx-auto max-w-5xl space-y-8 px-6 md:space-y-12">
         <div className="mx-auto max-w-xl space-y-6 text-center md:space-y-12">
           <ScrollView>
             <h2 className="text-balance text-4xl font-medium lg:text-5xl">
-              About Us
+              {t("about.title")}
             </h2>
           </ScrollView>
           <ScrollView>
-            <p>
-              What began as a love for clean design became a studio where design 
-              and code work together to deliver outcomes. We craft custom sites 
-              and web apps, from animated marketing pages to complex product UIs, 
-              with measurable gains in speed, conversion, and reliability. Fully 
-              remote, bilingual (RU/EN), global.
-            </p>
+            <p>{t("about.description")}</p>
           </ScrollView>
         </div>
         <ScrollView>
           <Image
             className="rounded-(--radius) grayscale-75 object-cover aspect-[16/9] w-full"
             src="/images/office.jpeg"
-            alt="team image"
+            alt={t("about.imageAlt")}
             height="480"
             width="720"
             priority

--- a/src/components/sections/home/hero-section.tsx
+++ b/src/components/sections/home/hero-section.tsx
@@ -148,7 +148,7 @@ const transitionVariants = {
                         href="https://t.me/microstudio_official"
                         target="_blank"
                       >
-                        <span className="text-nowrap">Talk to us</span>
+                        <span className="text-nowrap">{t('hero.cta.contact')}</span>
                       </Link>
                     </Button>
                   </div>
@@ -160,7 +160,7 @@ const transitionVariants = {
                     className="h-10.5 rounded-xl px-5"
                   >
                     <Link href="#portfolio">
-                      <span className="text-nowrap">See our work</span>
+                      <span className="text-nowrap">{t('hero.cta.work')}</span>
                     </Link>
                   </Button>
                 </AnimatedGroup>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,6 +8,10 @@ const resources = {
       hero: {
         title: 'Design With Intent, Engineering With Precision.',
         subtitle: 'Custom websites and web apps on modern stacks-fast delivery, strong reliability, real ROI.',
+        cta: {
+          contact: 'Talk to us',
+          work: 'See our work',
+        },
       },
       header: {
         nav: {
@@ -18,6 +22,30 @@ const resources = {
         },
         cta: 'Partner with us',
       },
+      about: {
+        title: 'About Us',
+        description:
+          'What began as a love for clean design became a studio where design and code work together to deliver outcomes. We craft custom sites and web apps, from animated marketing pages to complex product UIs, with measurable gains in speed, conversion, and reliability. Fully remote, bilingual (RU/EN), global.',
+        imageAlt: 'team image',
+        principles: [
+          {
+            title: 'Design × Engineering',
+            description: 'Clean design and robust code working together to deliver outcomes.',
+          },
+          {
+            title: 'Custom Web Experiences',
+            description: 'From animated marketing pages to complex product UIs.',
+          },
+          {
+            title: 'Measurable Impact',
+            description: 'Faster load times, higher conversion, and reliable performance.',
+          },
+          {
+            title: 'Distributed & Bilingual',
+            description: 'Fully remote team, RU/EN, operating worldwide.',
+          },
+        ],
+      },
     },
   },
   ru: {
@@ -25,6 +53,10 @@ const resources = {
       hero: {
         title: 'Дизайн с намерением, инженерия с точностью.',
         subtitle: 'Пользовательские сайты и веб-приложения на современных стеках — быстрая доставка, высокая надёжность, реальная окупаемость.',
+        cta: {
+          contact: 'Написать нам',
+          work: 'Посмотреть работы',
+        },
       },
       header: {
         nav: {
@@ -35,6 +67,30 @@ const resources = {
         },
         cta: 'Сотрудничать с нами',
       },
+      about: {
+        title: 'О нас',
+        description:
+          'Страсть к чистому дизайну превратилась в студию, где дизайн и код работают вместе ради результата. Мы создаём сайты и веб‑приложения: от анимированных промостраниц до сложных интерфейсов с ощутимым ростом скорости, конверсии и надёжности. Работаем полностью удалённо, говорим на RU/EN и сотрудничаем по всему миру.',
+        imageAlt: 'команда',
+        principles: [
+          {
+            title: 'Дизайн × Инженерия',
+            description: 'Чистый дизайн и надёжный код, работающие ради общего результата.',
+          },
+          {
+            title: 'Индивидуальные веб‑решения',
+            description: 'От анимированных промостраниц до сложных интерфейсов.',
+          },
+          {
+            title: 'Измеримый эффект',
+            description: 'Быстрая загрузка, выше конверсия и стабильная работа.',
+          },
+          {
+            title: 'Удалённая двуязычная команда',
+            description: 'Работаем из разных точек мира, говорим на RU/EN.',
+          },
+        ],
+      },
     },
   },
   es: {
@@ -42,6 +98,10 @@ const resources = {
       hero: {
         title: 'Diseño con intención, ingeniería con precisión.',
         subtitle: 'Sitios web y aplicaciones web personalizados con pilas modernas: entrega rápida, gran fiabilidad y verdadero retorno de inversión.',
+        cta: {
+          contact: 'Escríbenos',
+          work: 'Ver nuestro trabajo',
+        },
       },
       header: {
         nav: {
@@ -51,6 +111,30 @@ const resources = {
           portfolio: 'Portafolio',
         },
         cta: 'Colabora con nosotros',
+      },
+      about: {
+        title: 'Sobre nosotros',
+        description:
+          'Lo que comenzó como un amor por el diseño limpio se convirtió en un estudio donde el diseño y el código trabajan juntos para ofrecer resultados. Creamos sitios y aplicaciones web a medida, desde páginas de marketing animadas hasta interfaces de producto complejas, con mejoras medibles en velocidad, conversión y fiabilidad. Totalmente remotos, bilingües (RU/EN) y globales.',
+        imageAlt: 'equipo',
+        principles: [
+          {
+            title: 'Diseño × Ingeniería',
+            description: 'Diseño limpio y código sólido trabajando juntos para entregar resultados.',
+          },
+          {
+            title: 'Experiencias web a medida',
+            description: 'Desde páginas de marketing animadas hasta UIs de producto complejas.',
+          },
+          {
+            title: 'Impacto medible',
+            description: 'Cargas más rápidas, mayor conversión y rendimiento fiable.',
+          },
+          {
+            title: 'Distribuido y bilingüe',
+            description: 'Equipo totalmente remoto, RU/EN, operando en todo el mundo.',
+          },
+        ],
       },
     },
   },


### PR DESCRIPTION
## Summary
- translate hero buttons through i18n
- localize About Us section with i18n keys and Russian content

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to collect page data for /)*

------
https://chatgpt.com/codex/tasks/task_e_689bd647435c83229a70ac38c7893f80