### PR TITLE
refactor: memoize cursor and language switcher

### DIFF
--- a/src/components/custom-cursor-element.tsx
+++ b/src/components/custom-cursor-element.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useRef, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { Cursor } from "@/components/motion-primitives/cursor";
 import { AnimatePresence, motion } from "motion/react";
 
-export function CustomCursorElement({
+export const CustomCursorElement = memo(function CustomCursorElement({
   children,
   cursor,
   className = "",
@@ -15,14 +15,14 @@ export function CustomCursorElement({
   const [isHovering, setIsHovering] = useState(false);
   const targetRef = useRef<HTMLDivElement>(null);
 
-  const handlePositionChange = (x: number, y: number) => {
+  const handlePositionChange = useCallback((x: number, y: number) => {
     if (targetRef.current) {
       const rect = targetRef.current.getBoundingClientRect();
       const isInside =
         x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
       setIsHovering(isInside);
     }
-  };
+  }, []);
 
   return (
     <div className={className}>
@@ -66,4 +66,4 @@ export function CustomCursorElement({
       <div ref={targetRef}>{children}</div>
     </div>
   );
-}
+});

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -15,7 +15,7 @@ const LANGUAGES = [
   { code: "es", label: "Español" },
 ];
 
-export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
+const LanguageSwitcherComponent: React.FC<LanguageSwitcherProps> = ({
   className,
   align = "right",
 }) => {
@@ -33,10 +33,17 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
     return () => document.removeEventListener("click", handler);
   }, []);
 
-  const selectLanguage = (code: string) => {
-    i18n.changeLanguage(code);
-    setOpen(false);
-  };
+  const toggle = React.useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const selectLanguage = React.useCallback(
+    (code: string) => {
+      i18n.changeLanguage(code);
+      setOpen(false);
+    },
+    [i18n]
+  );
 
   return (
     <div ref={ref} className={cn("relative", className)}>
@@ -44,7 +51,7 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
         variant="outline"
         size="sm"
         className="cursor-pointer"
-        onClick={() => setOpen(!open)}
+        onClick={toggle}
       >
         <span>{i18n.language.slice(0, 2).toUpperCase()}</span>
       </Button>
@@ -69,3 +76,6 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
     </div>
   );
 };
+
+export const LanguageSwitcher = React.memo(LanguageSwitcherComponent);
+LanguageSwitcher.displayName = "LanguageSwitcher";


### PR DESCRIPTION
## Summary
- memoize `LanguageSwitcher` with stable callbacks
- memoize `CustomCursorElement` and its position handler

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689be33eee5c8322bd59acbf2f2422af