### PR TITLE
perf: split non-critical components and optimize icon imports

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,13 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  experimental: {
+    modularizeImports: {
+      "lucide-react": {
+        transform: "lucide-react/dist/esm/icons/{{kebabCase member}}",
+      },
+    },
+  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/src/components/sections/home/hero-section.tsx
+++ b/src/components/sections/home/hero-section.tsx
@@ -7,7 +7,12 @@ import { useTranslation } from "react-i18next";
 
 import { TextEffect } from "@/components/motion-primitives/text-effect";
 import { AnimatedGroup } from "@/components/motion-primitives/animated-group";
-import LogoCloud from "@/components/sections/home/logo-cloud";
+import dynamic from "next/dynamic";
+
+const LogoCloud = dynamic(
+  () => import("@/components/sections/home/logo-cloud"),
+  { ssr: true }
+);
 
 const transitionVariants = {
   item: {


### PR DESCRIPTION
## Summary
- lazy load LogoCloud with `next/dynamic`
- tree-shake lucide icons via `modularizeImports`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689be458f4b48322ad8ad934cc0f2e8d