### PR TITLE
perf: strip console statements and memoize footer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,11 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  compiler: {
+    removeConsole: {
+      exclude: ["error"],
+    },
+  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,11 +1,12 @@
 "use client";
+import { memo } from "react";
 import { Logo } from "@/components/logo";
 import Link from "next/link";
 import { motion } from "motion/react";
 import { ScrollView } from "./scroll-view";
 import { FOOTER_LINKS } from "@/content/footer";
 
-export default function FooterSection() {
+function FooterSection() {
   return (
     <footer className="py-16 md:py-32">
       <div className="mx-auto max-w-5xl px-6">
@@ -182,3 +183,5 @@ export default function FooterSection() {
     </footer>
   );
 }
+
+export default memo(FooterSection);


### PR DESCRIPTION
## Summary
- remove console calls from production bundles
- memoize footer component to prevent unnecessary rerenders

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689be6ab97cc8322bd37acaeefc2d479