### PR TITLE
fix: prevent negative blur keyframes

### DIFF
--- a/src/components/motion-primitives/text-effect.tsx
+++ b/src/components/motion-primitives/text-effect.tsx
@@ -175,9 +175,9 @@ const createVariantsWithTransition = (
   baseVariants: Variants,
   transition?: Transition & { exit?: Transition }
 ): Variants => {
-  if (!transition) return baseVariants;
+  const { exit: exitTransition, ...mainTransition } = transition ?? {};
 
-  const { exit: _, ...mainTransition } = transition;
+  const defaultTransition: Transition = { type: 'tween' };
 
   return {
     ...baseVariants,
@@ -187,6 +187,7 @@ const createVariantsWithTransition = (
         ...(hasTransition(baseVariants.visible)
           ? baseVariants.visible.transition
           : {}),
+        ...defaultTransition,
         ...mainTransition,
       },
     },
@@ -196,7 +197,9 @@ const createVariantsWithTransition = (
         ...(hasTransition(baseVariants.exit)
           ? baseVariants.exit.transition
           : {}),
+        ...defaultTransition,
         ...mainTransition,
+        ...exitTransition,
         staggerDirection: -1,
       },
     },

--- a/src/components/scroll-view.tsx
+++ b/src/components/scroll-view.tsx
@@ -27,11 +27,12 @@ export const ScrollView = memo(function ScrollView({
             delay: delay,
             staggerChildren: stagger ? 0.09 : 0,
             duration: 0.5,
+            type: "tween",
           },
         },
       }}
       viewOptions={{ margin: viewMargin }}
-      transition={{ duration: 0.3, ease: "easeInOut" }}
+      transition={{ duration: 0.3, ease: "easeInOut", type: "tween" }}
     >
       {children}
     </InView>
@@ -55,6 +56,7 @@ export const ScrollViewStaggerWrapper = memo(function ScrollViewStaggerWrapper({
           filter: "blur(0px)",
         },
       }}
+      transition={{ type: "tween" }}
       className={className}
     >
       {children}

--- a/src/components/sections/home/services-2.tsx
+++ b/src/components/sections/home/services-2.tsx
@@ -92,6 +92,7 @@ export default function ServicesSection2() {
                             transition: {
                               delay: 0.01,
                               duration: 0.5,
+                              type: "tween",
                             },
                           },
                         }}
@@ -99,7 +100,7 @@ export default function ServicesSection2() {
                           margin: "0px 0px -250px 0px",
                           once: true,
                         }}
-                        transition={{ duration: 0.3, ease: "easeInOut" }}
+                        transition={{ duration: 0.3, ease: "easeInOut", type: "tween" }}
                       >
                         <Link href={service.url}>
                           <Image


### PR DESCRIPTION
## Summary
- ensure tween transitions in text effects
- use tween transitions in scroll view animations
- apply tween transition to services section images

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689be7f59b988322ad7deb1d061bfbb0