### PR TITLE
fix: remove broken testimonial avatars and correct image dimensions

### DIFF
--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -29,8 +29,8 @@ export default function ContentSection() {
             className="rounded-(--radius) grayscale-75 object-cover aspect-[16/9] w-full"
             src="/images/office.jpeg"
             alt={t("about.imageAlt")}
-            height="480"
-            width="720"
+            height={480}
+            width={720}
             priority
           />
         </ScrollView>

--- a/src/components/portfolio-card.tsx
+++ b/src/components/portfolio-card.tsx
@@ -22,8 +22,8 @@ export default function PortfolioCard({
             <a href={card.url} target="_blank" rel="noreferrer">
               <Image
                 className=" w-full grayscale-25 hover:grayscale-0 rounded-md object-cover object-top  transition-all duration-500  "
-                height="480"
-                width="720"
+                height={480}
+                width={720}
                 src={card.img}
                 alt={card.name}
               />

--- a/src/components/sections/home/services-2.tsx
+++ b/src/components/sections/home/services-2.tsx
@@ -106,8 +106,8 @@ export default function ServicesSection2() {
                           <Image
                             src={service.img}
                             alt={service.name}
-                            height="480"
-                            width="720"
+                            height={480}
+                            width={720}
                             loading="lazy"
                             className=" object-cover object-top  transition-all duration-500 w-full  aspect-[16/9]"
                           />

--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import Image from "next/image";
 import { ScrollView } from "./scroll-view";
 
@@ -47,13 +49,6 @@ export default function Testimonials() {
 
                   <div className="grid grid-cols-[auto_1fr] items-center gap-3">
                     <Avatar className="size-12">
-                      <AvatarImage
-                        src="https://tailus.io/images/reviews/shekinah.webp"
-                        alt="Shekinah Tshiokufila"
-                        height="400"
-                        width="400"
-                        loading="lazy"
-                      />
                       <AvatarFallback>ST</AvatarFallback>
                     </Avatar>
 
@@ -79,13 +74,6 @@ export default function Testimonials() {
 
                   <div className="grid grid-cols-[auto_1fr] items-center gap-3">
                     <Avatar className="size-12">
-                      <AvatarImage
-                        src="https://tailus.io/images/reviews/jonathan.webp"
-                        alt="Jonathan Yombo"
-                        height="400"
-                        width="400"
-                        loading="lazy"
-                      />
                       <AvatarFallback>JY</AvatarFallback>
                     </Avatar>
                     <div>
@@ -110,13 +98,6 @@ export default function Testimonials() {
 
                   <div className="grid items-center gap-3 [grid-template-columns:auto_1fr]">
                     <Avatar className="size-12">
-                      <AvatarImage
-                        src="https://tailus.io/images/reviews/yucel.webp"
-                        alt="Yucel Faruksahan"
-                        height="400"
-                        width="400"
-                        loading="lazy"
-                      />
                       <AvatarFallback>YF</AvatarFallback>
                     </Avatar>
                     <div>
@@ -141,13 +122,6 @@ export default function Testimonials() {
 
                   <div className="grid grid-cols-[auto_1fr] gap-3">
                     <Avatar className="size-12">
-                      <AvatarImage
-                        src="https://tailus.io/images/reviews/rodrigo.webp"
-                        alt="Rodrigo Aguilar"
-                        height="400"
-                        width="400"
-                        loading="lazy"
-                      />
                       <AvatarFallback>YF</AvatarFallback>
                     </Avatar>
                     <div>


### PR DESCRIPTION
## Summary
- remove broken testimonial avatar images and show initials instead
- use numeric width/height for Next.js Image components to prevent invalid `imagesrcset`
- mark testimonials component as client-side to avoid hydration mismatch

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689bea30c0c0832288f71413d7b05092