### PR TITLE
fix: provide sizes for preload image

### DIFF
--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -31,6 +31,7 @@ export default function ContentSection() {
             alt={t("about.imageAlt")}
             height={480}
             width={720}
+            sizes="100vw"
             priority
           />
         </ScrollView>


### PR DESCRIPTION
## Summary
- specify `sizes="100vw"` for about page hero image so preload link has valid `imagesrcset` and `imagesizes`

## Testing
- `pnpm build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf0d4f05883229f15ae647e8188e8